### PR TITLE
Add a general purpose console.log() import.

### DIFF
--- a/wasmRunner.mjs
+++ b/wasmRunner.mjs
@@ -3,6 +3,7 @@ export class WasmRunner {
     this.wasmModule = wasmModule;
     return WebAssembly.instantiate(this.wasmModule, {
       console: {
+        log: this.log,
         log_i32_s: this.log_i32_s,
         log_i32_u: this.log_i32_u,
         log_i64_s: this.log_i64_s,
@@ -35,6 +36,13 @@ export class WasmRunner {
 
   get exports() {
     return this.instance.exports;
+  }
+
+  /**
+   * @param value
+   */
+  log(value) {
+    console.log(value);
   }
 
   /**

--- a/wasmRunner.spec.js
+++ b/wasmRunner.spec.js
@@ -6,6 +6,7 @@ import { WasmRunner } from "./wasmRunner.mjs";
 
 let wasmModule;
 let currentInstance;
+let mock_log;
 let mock_log_i32_s;
 let mock_log_i32_u;
 let mock_log_i64_s;
@@ -36,6 +37,7 @@ beforeAll(async () => {
     console.log(`Error compiling *.wat: ${err}`);
     process.exit(1);
   }
+  mock_log = jest.spyOn(WasmRunner.prototype, "log");
   mock_log_i32_s = jest.spyOn(WasmRunner.prototype, "log_i32_s");
   mock_log_i32_u = jest.spyOn(WasmRunner.prototype, "log_i32_u");
   mock_log_i64_s = jest.spyOn(WasmRunner.prototype, "log_i64_s");
@@ -60,6 +62,7 @@ beforeAll(async () => {
 describe("WasmRunner", () => {
   beforeEach(async () => {
     currentInstance = null;
+    mock_log.mockClear();
     mock_log_i32_s.mockClear();
     mock_log_i32_u.mockClear();
     mock_log_i64_s.mockClear();
@@ -90,6 +93,15 @@ describe("WasmRunner", () => {
       console.log(`Error instantiating WebAssembly module: ${err}`);
       return Promise.reject();
     }
+  });
+
+  test("log", () => {
+    currentInstance.exports.test_log();
+    expect(mock_log).toHaveBeenCalled();
+    expect(mock_log.mock.calls.length).toBe(1);
+    expect(typeof mock_log.mock.calls[0][0]).toEqual("number");
+    expect(mock_log.mock.calls[0][0]).toBe(42);
+    expect(mock_console.mock.calls[0][0]).toEqual(42);
   });
 
   test("log_i32_s", () => {

--- a/wasmRunnerDriver.wat
+++ b/wasmRunnerDriver.wat
@@ -1,4 +1,5 @@
 (module
+  (import "console" "log" (func $log (param i32)))
   (import "console" "log_i32_s" (func $log_i32_s (param i32)))
   (import "console" "log_i32_u" (func $log_i32_u (param i32)))
   (import "console" "log_i64_s" (func $log_i64_s (param i64)))
@@ -20,6 +21,10 @@
 
   (memory (export "mem") 1)
   (data (i32.const 64) "Goodbye, Mars!")
+
+  (func (export "test_log")
+    (call $log (i32.const 42))
+  )
 
   (func (export "test_log_i32_s")
     (call $log_i32_s (i32.const 99))


### PR DESCRIPTION
Many WebAssembly tutorials, including the example code on MDN, use a `"console" "log"` import. I thought it would be good to add this import to avoid confusion when people copy/paste example code into their Exercism exercise.

`WasmRunner` has plenty of alternative logging functions (including `log_i32_u()` that is also just a `console.log()` call) but it's not obvious they exist if you don't look into this source file. And if you're a WASM beginner (like me) you might not even realize that the `"console" "log"` import has to be defined somewhere ahead of time.