### PR TITLE
feat: Improve error messages

### DIFF
--- a/compile-wat.mjs
+++ b/compile-wat.mjs
@@ -25,12 +25,6 @@ export async function compileWat(watPath, optionsOverrides) {
     ...defaultWabtOptions,
     ...optionsOverrides,
   });
-  
-  // Unconditionally write the desugared Form to the console
-  module.generateNames();
-  const text = module.toText({ foldExprs: false, inlineExport: false });
-  console.log(`Desugared Form: \n${text}`);
-  
   // Call validate on the text format so errors highlight source WAT
   module.validate();
 

--- a/compile-wat.mjs
+++ b/compile-wat.mjs
@@ -4,24 +4,35 @@ import initWabt from "wabt";
 let defaultWabtOptions = {
   exceptions: true,
   mutable_globals: true,
-  set_float_to_int: true,
+  sat_float_to_int: true,
   sign_extension: true,
   simd: true,
   threads: false,
+  function_references: true,
   multi_value: true,
   bulk_memory: true,
   reference_types: true,
   annotations: true,
+  code_metadata: true,
   gc: false,
+  memory64: false,
 };
 
 // Reads a *.wat file, parses to a *.wasm binary in-memory, and then compiles to a Wasm module we can instantiate
 export async function compileWat(watPath, optionsOverrides) {
   const wabt = await initWabt();
-  return wabt
-    .parseWat(watPath, readFileSync(watPath, "utf8"), {
-      ...defaultWabtOptions,
-      ...optionsOverrides,
-    })
-    .toBinary({ write_debug_names: true });
+  const module = wabt.parseWat(watPath, readFileSync(watPath, "utf8"), {
+    ...defaultWabtOptions,
+    ...optionsOverrides,
+  });
+  
+  // Unconditionally write the desugared Form to the console
+  module.generateNames();
+  const text = module.toText({ foldExprs: false, inlineExport: false });
+  console.log(`Desugared Form: \n${text}`);
+  
+  // Call validate on the text format so errors highlight source WAT
+  module.validate();
+
+  return module.toBinary({ write_debug_names: true });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exercism/wasm-lib",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "",
   "author": "Sean McBride",
   "license": "MIT",
@@ -21,7 +21,7 @@
     "jest": "^27.5.0"
   },
   "dependencies": {
-    "wabt": "^1.0.26"
+    "wabt": "^1.0.32"
   },
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js ./*",


### PR DESCRIPTION
I've only tested this by linking locally. I'm not really sure about how to publish this new version / update the wasm track. Help would be appreciated!

Previously, we were validating the wasm binary, which resulted in more opaque error messages that reference a byte offset into the binary:

```
Error compiling *.wat: 
    CompileError: WebAssembly.compile(): Compiling function #0 failed: expected 2 elements on the stack for fallthru, found 4 @+57
```

Now error messages reference the WAT provided by the user:

```
    Error compiling *.wat: 
    Error: validate failed:
    11:21: error: type mismatch at end of function, expected [] but got [i32, i32]
        (i32.const 64) (i32.const 14)
                               ^^^^^^
```

While in here, I updated the WABT dependency and enabled a few experimental wasm proposals in case our students want to use them.

Associated Forum Thread at https://forum.exercism.org/t/improved-wasm-error-messages/8209